### PR TITLE
gaイベントタグの追加

### DIFF
--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -9,12 +9,12 @@
 <% @articles.each do |article| %>
     <tr>
       <td>
-        <a href=<%= article.url %> target=”_blank”><img src=<%= article.url_thumbnail %> alt=<%= article.url_title %> width="60" align="right"></a>
-        <h4><a href=<%= article.url %> target=”_blank”><%= article.title %></a></h4>
-        <h5><a href=<%= article.url %> target=”_blank”><%= article.url_title %></a></h5>
+        <a href=<%= article.url %> onclick="ga('send', 'event', 'Article', 'click_img', <%= article.url %>);" target=”_blank”><img src=<%= article.url_thumbnail %> alt=<%= article.url_title %> width="60" align="right"></a>
+        <h4><a href=<%= article.url %> onclick="ga('send', 'event', 'Article', 'click_title', <%= article.url %>);" target=”_blank”><%= article.title %></a></h4>
+        <h5><a href=<%= article.url %> onclick="ga('send', 'event', 'Article', 'click_url_title', <%= article.url %>);" target=”_blank”><%= article.url_title %></a></h5>
         <h6><%= truncate(article.url_description, length:200) %></h6>
         <div align="right">
-        <button type="button" class="btn btn-primary btn-xs" id="<%= article.id %>" onclick="good(<%= article.id %>)">ぱねぇ！</button> 
+        <button type="button" class="btn btn-primary btn-xs" id="<%= article.id %>" onclick="good(<%= article.id %>)">ぱねぇ！</button>
         <span id="num<%= article.id %>"><%= article.feelings_count %></span>人
         <h6>
           <% if article.user_id.to_i == current_user.id.to_i %>


### PR DESCRIPTION
* 記事リンク押下時に、GAにイベント情報を送信するように修正
* GA サイドメニュー行動→イベントにて、セッションごとのクリックを終えるようになる
* 外部リンク箇所ごとに、eventActionを変更
  * 画像部分→click_img
  * タイトル→click_title
  * URLタイトル→click_url_title